### PR TITLE
[DO NOT MERGE] ref #4311 - changes to hammer-cli-foreman changed some class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ class MyAsyncCommand < HammerCLIForemanTasks::AsyncCommand
   success_message "Task started with id %{id}s"
   failure_message "Could not run the task"
 
-  apipie_options
+  build_options
 end
 ```
 

--- a/lib/hammer_cli_foreman_tasks/async_command.rb
+++ b/lib/hammer_cli_foreman_tasks/async_command.rb
@@ -13,6 +13,6 @@ module HammerCLIForemanTasks
       end
     end
 
-    apipie_options
+    build_options
   end
 end

--- a/lib/hammer_cli_foreman_tasks/task.rb
+++ b/lib/hammer_cli_foreman_tasks/task.rb
@@ -8,7 +8,7 @@ module HammerCLIForemanTasks
       include HammerCLIForemanTasks::Helper
 
       action :show
-      apipie_options
+      build_options
 
       command_name "progress"
       desc "Show the progress of the task"


### PR DESCRIPTION
more specifically, `WriteCommand` and `ReadCommand` no longer exist
