### PR TITLE
bump to version 0.0.3

### DIFF
--- a/hammer_cli_foreman_tasks.gemspec
+++ b/hammer_cli_foreman_tasks.gemspec
@@ -19,6 +19,6 @@ DESC
 
   s.files = Dir["lib/**/*", "LICENSE", "README.md"]
 
-  s.add_dependency "powerbar"
-  s.add_dependency "hammer_cli_foreman"
+  s.add_dependency "powerbar", "~> 1.0.11"
+  s.add_dependency "hammer_cli_foreman", "~> 0.1.1"
 end

--- a/lib/hammer_cli_foreman_tasks/version.rb
+++ b/lib/hammer_cli_foreman_tasks/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForemanTasks
   def self.version
-    @version ||= Gem::Version.new('0.0.2')
+    @version ||= Gem::Version.new('0.0.3')
   end
 end


### PR DESCRIPTION
hammer_cli was bumped to `0.1.1` (20 may 2014)
hammer_cli_foreman was bumped to `0.1.1` (20 may 2014)
hammer_cli_katello was bumped to `0.0.4` (22 may 2014)

locking down versions of powerbar and hammer_cli_foreman

this PR corresponds with Katello/hammer-cli-katello#175
