### PR TITLE
limit async tasks output incase of file redirection of csv

### DIFF
--- a/lib/hammer_cli_foreman_tasks/task_progress.rb
+++ b/lib/hammer_cli_foreman_tasks/task_progress.rb
@@ -11,11 +11,7 @@ module HammerCLIForemanTasks
 
     def render
       update_task
-      if task_pending?
-        render_progress
-      else
-        render_result
-      end
+      render_progress
     end
 
     private
@@ -24,7 +20,7 @@ module HammerCLIForemanTasks
       progress_bar do |bar|
         begin
           while true
-            bar.show(:msg => "Task #{@task_id} #{@task['result']}", :done => @task['progress'].to_f, :total => 1)
+            bar.show(:msg => progress_message, :done => @task['progress'].to_f, :total => 1)
             if task_pending?
               sleep interval
               update_task
@@ -36,6 +32,10 @@ module HammerCLIForemanTasks
           # Inerrupting just means we stop rednering the progress bar
         end
       end
+    end
+
+    def progress_message
+      "Task #{@task_id} #{task_pending? ? @task['state'] : @task['result']}"
     end
 
     def render_result

--- a/lib/hammer_cli_foreman_tasks/task_progress.rb
+++ b/lib/hammer_cli_foreman_tasks/task_progress.rb
@@ -24,7 +24,7 @@ module HammerCLIForemanTasks
       progress_bar do |bar|
         begin
           while true
-            bar.show(:msg => "Task #{@task_id} progress", :done => @task['progress'].to_f, :total => 1)
+            bar.show(:msg => "Task #{@task_id} #{@task['result']}", :done => @task['progress'].to_f, :total => 1)
             if task_pending?
               sleep interval
               update_task
@@ -39,7 +39,6 @@ module HammerCLIForemanTasks
     end
 
     def render_result
-      puts "Task %{uuid}: %{result}" % { :uuid => @task_id, :result => @task['result'] }
       unless @task['humanized']['output'].to_s.empty?
         puts @task['humanized']['output']
       end


### PR DESCRIPTION
i am making this change specifically for `hammer-cli-gutterball`. hcli-gutterball's reports are CSV but they are also asynchronous. The plan is for a user to redirect this CSV into a file, but we can't have task information getting `puts`'d into the file as well.

command as an example:
```sh
hammer content-report content-host-status --organization-id 1 > file.csv
```

contents of `file.csv` prior to this pull-request:
```csv
Task 1e65f354-faf5-43be-9f08-36c07ab22112: success
Hostname,Status
sys-1-78313841,invalid
sys-2-32923247,invalid
sys-3-43353579,invalid
sys-4-52605020,invalid
sys-5-46648112,invalid
```

contents of `file.csv` after this pull-request:
```csv
Hostname,Status
sys-1-78313841,invalid
sys-2-32923247,invalid
sys-3-43353579,invalid
sys-4-52605020,invalid
sys-5-46648112,invalid
```

**Note**: Katello/foreman-gutterball#16 and Katello/hammer-cli-gutterball#3 are necessary to try this exact command out.