### PR TITLE
bump version to 0.0.6

### DIFF
--- a/hammer_cli_foreman_tasks.gemspec
+++ b/hammer_cli_foreman_tasks.gemspec
@@ -20,5 +20,5 @@ DESC
   s.files = Dir["{lib,config}/**/*", "LICENSE", "README.md"]
 
   s.add_dependency "powerbar", "~> 1.0.11"
-  s.add_dependency "hammer_cli_foreman", "~> 0.1.1"
+  s.add_dependency "hammer_cli_foreman", "> 0.1.1", "< 0.3.0"
 end

--- a/lib/hammer_cli_foreman_tasks/version.rb
+++ b/lib/hammer_cli_foreman_tasks/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForemanTasks
   def self.version
-    @version ||= Gem::Version.new('0.0.5')
+    @version ||= Gem::Version.new('0.0.6')
   end
 end


### PR DESCRIPTION
to account for new minor version of hammer-cli indirectly through
hammer-cli-foreman