### PR TITLE
Fixes #10647: Don't return success if task results in an error.

### DIFF
--- a/lib/hammer_cli_foreman_tasks/async_command.rb
+++ b/lib/hammer_cli_foreman_tasks/async_command.rb
@@ -11,8 +11,8 @@ module HammerCLIForemanTasks
       if option_async?
         super
       else
-        task_progress(send_request)
-        HammerCLI::EX_OK
+        success = task_progress(send_request)
+        success ? HammerCLI::EX_OK : HammerCLI::EX_SOFTWARE
       end
     end
 

--- a/lib/hammer_cli_foreman_tasks/helper.rb
+++ b/lib/hammer_cli_foreman_tasks/helper.rb
@@ -4,9 +4,9 @@ module HammerCLIForemanTasks
     # render the progress of the task using polling to the task API
     def task_progress(task_or_id)
       task_id = task_or_id.is_a?(Hash) ? task_or_id['id'] : task_or_id
-      TaskProgress.new(task_id) { |id| load_task(id) }.tap do |task_progress|
-        task_progress.render
-      end
+      task_progress = TaskProgress.new(task_id) { |id| load_task(id) }
+      task_progress.render
+      task_progress.success?
     end
 
     def load_task(id)

--- a/lib/hammer_cli_foreman_tasks/task.rb
+++ b/lib/hammer_cli_foreman_tasks/task.rb
@@ -14,8 +14,8 @@ module HammerCLIForemanTasks
       desc _("Show the progress of the task")
 
       def execute
-        task_progress(option_id)
-        HammerCLI::EX_OK
+        success = task_progress(option_id)
+        success ? HammerCLI::EX_OK : HammerCLI::EX_SOFTWARE
       end
 
     end

--- a/lib/hammer_cli_foreman_tasks/task_progress.rb
+++ b/lib/hammer_cli_foreman_tasks/task_progress.rb
@@ -14,6 +14,10 @@ module HammerCLIForemanTasks
       render_progress
     end
 
+    def success?
+      @task[:result] != 'error'
+    end
+
     private
 
     def render_progress
@@ -40,7 +44,7 @@ module HammerCLIForemanTasks
 
     def render_result
       puts @task['humanized']['output'] unless @task['humanized']['output'].to_s.empty?
-      STDERR.puts @task['humanized']['errors'].join("\n") unless @task['humanized']['errors'].to_s.empty?
+      STDERR.puts "Error: #{@task['humanized']['errors'].join("\n")}" unless @task['humanized']['errors'].empty?
     end
 
     def update_task


### PR DESCRIPTION
Previously no matter the result of the task, the CLI would return
success which means that if using show or the mixin in other CLI
commands automated scripts would continue even though a failure
had a occurred.