### PR TITLE
Fixes #12647 - Aysnc commands with errors will exit with new code

### DIFF
--- a/lib/hammer_cli_foreman_tasks/async_command.rb
+++ b/lib/hammer_cli_foreman_tasks/async_command.rb
@@ -11,8 +11,8 @@ module HammerCLIForemanTasks
       if option_async?
         super
       else
-        task_progress(send_request)
-        HammerCLI::EX_OK
+        exit_code = task_progress(send_request)
+        exit_code
       end
     end
 

--- a/lib/hammer_cli_foreman_tasks/helper.rb
+++ b/lib/hammer_cli_foreman_tasks/helper.rb
@@ -4,9 +4,9 @@ module HammerCLIForemanTasks
     # render the progress of the task using polling to the task API
     def task_progress(task_or_id)
       task_id = task_or_id.is_a?(Hash) ? task_or_id['id'] : task_or_id
-      TaskProgress.new(task_id) { |id| load_task(id) }.tap do |task_progress|
-        task_progress.render
-      end
+      task_progress = TaskProgress.new(task_id) { |id| load_task(id) }
+      task_progress.render
+      task_progress.exit_code
     end
 
     def load_task(id)

--- a/lib/hammer_cli_foreman_tasks/task_progress.rb
+++ b/lib/hammer_cli_foreman_tasks/task_progress.rb
@@ -1,7 +1,7 @@
 require 'powerbar'
 module HammerCLIForemanTasks
   class TaskProgress
-    attr_accessor :interval, :task
+    attr_accessor :interval, :task, :exit_code
 
     def initialize(task_id, &block)
       @update_block = block
@@ -41,6 +41,7 @@ module HammerCLIForemanTasks
     def render_result
       puts @task['humanized']['output'] unless @task['humanized']['output'].to_s.empty?
       STDERR.puts @task['humanized']['errors'].join("\n") unless @task['humanized']['errors'].to_s.empty?
+      self.exit_code = @task['humanized']['errors'].to_s.empty? ? HammerCLI::EX_OK : HammerCLI::EX_DATAERR
     end
 
     def update_task


### PR DESCRIPTION
This gives the Async tasks the ability to exit with exit_codes used in HammerCli. Before even if the task failed it gave the exit code 0, which is used to indicate that it was successful.