### PR TITLE
Fixes #17358 - task progress accepts NIL value for id

### DIFF
--- a/lib/hammer_cli_foreman_tasks/helper.rb
+++ b/lib/hammer_cli_foreman_tasks/helper.rb
@@ -1,17 +1,19 @@
 module HammerCLIForemanTasks
   module Helper
-
     # render the progress of the task using polling to the task API
     def task_progress(task_or_id)
       task_id = task_or_id.is_a?(Hash) ? task_or_id['id'] : task_or_id
-      task_progress = TaskProgress.new(task_id) { |id| load_task(id) }
-      task_progress.render
-      task_progress.success?
+      if !task_id.empty?
+        task_progress = TaskProgress.new(task_id) { |id| load_task(id) }
+        task_progress.render
+        task_progress.success?
+      else
+        signal_usage_error(_('Please mention appropriate attribute value'))
+      end
     end
 
     def load_task(id)
       HammerCLIForeman.foreman_resource!(:foreman_tasks).call(:show, :id => id)
     end
-
   end
 end


### PR DESCRIPTION
Issue: Currently the hammer command accepts NIL or Empty value as a parameter value for `id` attribute resulting in calling the `index` action for task instead of `show` action. 

Fixed as : Appropriate message is to be shown if no value is given for an id attribute before hitting the actual foreman server.