### PR TITLE
Fixes #7451 - Review whitespace in extracted strings

### DIFF
--- a/lib/hammer_cli_foreman_tasks/recurring_logic.rb
+++ b/lib/hammer_cli_foreman_tasks/recurring_logic.rb
@@ -23,12 +23,12 @@ module HammerCLIForemanTasks
       action :cancel
       command_name 'cancel'
       success_message _('Recurring logic cancelled.')
-      failure_message _('Could not cancel the recurring logic.')
+      failure_message _('Could not cancel the recurring logic')
       build_options
     end
 
     autoload_subcommands
   end
 
-  HammerCLI::MainCommand.subcommand 'recurring-logic', _('Recurring logic related actions.'), RecurringLogic
+  HammerCLI::MainCommand.subcommand 'recurring-logic', _('Recurring logic related actions'), RecurringLogic
 end


### PR DESCRIPTION
related to: https://github.com/Katello/hammer-cli-katello/pull/536