### PR TITLE
Fixes #28800 - progress doesnt check if errors is null

### DIFF
--- a/lib/hammer_cli_foreman_tasks/task_progress.rb
+++ b/lib/hammer_cli_foreman_tasks/task_progress.rb
@@ -45,7 +45,9 @@ module HammerCLIForemanTasks
 
     def render_result
       puts @task['humanized']['output'] if !@task['humanized']['output'].to_s.empty? && appropriate_verbosity?
-      STDERR.puts "Error: #{@task['humanized']['errors'].join("\n")}" unless @task['humanized']['errors'].empty?
+      unless @task['humanized']['errors'].nil? || @task['humanized']['errors'].empty?
+        STDERR.puts "Error: #{@task['humanized']['errors'].join("\n")}"
+      end
     end
 
     def update_task


### PR DESCRIPTION
When using hammer task progress --id `_id_`
the output was:
[..........................................................................................................................................................................................................] [100%]
Error: undefined method `empty?' for nil:NilClass

now it will only be the progress