### PR TITLE
Relax dependency version

### DIFF
--- a/hammer_cli_foreman_tasks.gemspec
+++ b/hammer_cli_foreman_tasks.gemspec
@@ -21,5 +21,5 @@ DESC
   s.require_paths = ["lib"]
 
   s.add_dependency "powerbar", ">= 1.0.11", "< 3.0"
-  s.add_dependency "hammer_cli_foreman", "> 0.1.1", "< 1.0.0"
+  s.add_dependency "hammer_cli_foreman", "> 0.1.1"
 end


### PR DESCRIPTION
Core moved to 2.0.0 already and this prevents from installing the dep.