### PR TITLE
Fixes #30733 - Add logic for returned job_invocation json

### DIFF
--- a/lib/hammer_cli_foreman_tasks/helper.rb
+++ b/lib/hammer_cli_foreman_tasks/helper.rb
@@ -2,7 +2,14 @@ module HammerCLIForemanTasks
   module Helper
     # render the progress of the task using polling to the task API
     def task_progress(task_or_id)
-      task_id = task_or_id.is_a?(Hash) ? task_or_id['id'] : task_or_id
+      task_id = case task_or_id
+      when Hash
+        task_or_id['id']
+      when Array
+        Hash[*task_or_id.flatten(1)]['task_id']
+      else
+        task_or_id
+      end
       if !task_id.empty?
         options = { verbosity: @context[:verbosity] || HammerCLI::V_VERBOSE }
         task_progress = TaskProgress.new(task_id, options) { |id| load_task(id) }


### PR DESCRIPTION
Tested with a few commands that return tasks normally and they did not break with this change. 