### PR TITLE
Fixes #38402 - Do not use humanized input

### DIFF
--- a/lib/hammer_cli_foreman_tasks/task.rb
+++ b/lib/hammer_cli_foreman_tasks/task.rb
@@ -8,13 +8,6 @@ module HammerCLIForemanTasks
       end
     end
 
-    module ActionField
-      def extend_data(task)
-        task["action"] = [task["humanized"]["action"], task["humanized"]["input"]].join(' ')
-        task
-      end
-    end
-
     class ProgressCommand < HammerCLIForeman::Command
       include HammerCLIForemanTasks::Helper
 
@@ -37,7 +30,6 @@ module HammerCLIForemanTasks
 
     class ListCommand < HammerCLIForeman::ListCommand
       extend WithoutNameOption
-      include ActionField
 
       output do
         field :id, _('ID')
@@ -59,7 +51,6 @@ module HammerCLIForemanTasks
 
     class InfoCommand < HammerCLIForeman::InfoCommand
       extend WithoutNameOption
-      include ActionField
 
       output do
         field :id, _('ID')


### PR DESCRIPTION
Sometimes, humanized input is a composite array, and then the output
looks like this:

```
hammer task list --fields Action
...
Promote content_view {"text"=>"content view 'CV-1'", "link"=>"/content_views/...
Publish content_view {"text"=>"content view 'CV-1'", "link"=>"/content_views/...
Update content_view {"text"=>"content view 'CV-1'", "link"=>"/content_views/2...
Synchronize repository {"text"=>"repository 'Red Hat Ansible Engine 2 for RHE...
```

Using field["Action"] removes this issue with no apparent repercussions.