### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_tasks.gemspec
+++ b/hammer_cli_foreman_tasks.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib,config,locale}/**/*", "LICENSE", "README.md"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "hammer_cli_foreman", "> 0.1.1", "< 4.0.0"
+  s.add_dependency "hammer_cli_foreman", "> 0.1.1", "< 6.0.0"
   s.add_dependency "powerbar", ">= 1.0.11", "< 3.0"
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint to < 6.0.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)